### PR TITLE
fix: update Windows package script count

### DIFF
--- a/windows/Build-Windows-Release.ps1
+++ b/windows/Build-Windows-Release.ps1
@@ -337,7 +337,7 @@ function Assert-StagedRuntimeIntegrity([string]$PackageRoot, [string]$ArchiveNam
     }
 
     $powerShellFiles = @(Get-ChildItem -LiteralPath (Join-Path $PackageRoot "windows") -Filter "*.ps1" -File)
-    Assert-True ($powerShellFiles.Count -eq 4) "The staged Windows workflow must contain exactly four player-facing PowerShell scripts."
+    Assert-True ($powerShellFiles.Count -eq 3) "The staged Windows workflow must contain exactly three player-facing PowerShell scripts."
     foreach ($scriptFile in $powerShellFiles) {
         $tokens = $null
         $parseErrors = $null


### PR DESCRIPTION
## What changed
Update the strict Windows release-package assertion from four PowerShell scripts to three after the obsolete local key-copy tool was removed.

## Why
The allowlist was correct, but the independent file-count assertion still described the old workflow and correctly stopped the v2.0.2 build.

## Validation
- complete v2.0.2 Windows release build passed
- staged allowlist and archive integrity checks passed
- generated ZIP SHA256: `8a37a041be12a64d8ba5b340fffb0e1eb73dc7b63a00952fe6a00b195f37f20b`